### PR TITLE
$Location isn't a mandatory property

### DIFF
--- a/AdsiPS/Public/New-ADSISiteSubnet.ps1
+++ b/AdsiPS/Public/New-ADSISiteSubnet.ps1
@@ -71,7 +71,12 @@
 			IF ($PSCmdlet.ShouldProcess($SubnetName, "Create new Subnet"))
 			{
 				$Subnet = New-Object -TypeName System.DirectoryServices.ActiveDirectory.ActiveDirectorysubnet -ArgumentList $Context, $SubnetName, $SiteName
-				$Subnet.Location = $Location
+
+				if ($PSBoundParameters['Location']) 
+				{
+					$Subnet.Location = $Location
+				}
+				
 				$Subnet.Save()
 				
 				#$SubnetEntry = $Subnet.GetDirectoryEntry()


### PR DESCRIPTION
Since the Location parameter isn't mandatory it seems like it should only be stored if it's set as a parameter (or make the parameter mandatory).  btw...hope you don't mind.  I've been meaning to do something similar to what you did, but didn't find the time (all my ADSI modules are locked down do to intellectual property restrictions).  So figured I'd help where i can.