### PR TITLE
Fix #39 Credential and DomainName params were being ignored

### DIFF
--- a/AdsiPS/Public/Add-ADSIGroupMember.ps1
+++ b/AdsiPS/Public/Add-ADSIGroupMember.ps1
@@ -17,7 +17,7 @@ function Add-ADSIGroupMember
         SamAccountName
         Sid
         UserPrincipalName
-    
+
     Those properties come from the following enumeration:
         System.DirectoryServices.AccountManagement.IdentityType
 
@@ -34,7 +34,7 @@ function Add-ADSIGroupMember
     Specifies the alternative Domain where the user should be created
     By default it will use the current domain.
 
-.EXAMPLE 
+.EXAMPLE
     Add-ADSIGroupMember -Identity TestADSIGroup -Member 'UserTestAccount1'
 
     Adding the User account 'UserTestAccount1' to the group 'TestADSIGroup'
@@ -59,7 +59,7 @@ function Add-ADSIGroupMember
 PARAM(
     [parameter(Mandatory=$true, ValueFromPipelineByPropertyName=$true, ValueFromPipeline=$true)]
     $Identity,
-    
+
     [Alias("RunAs")]
     [System.Management.Automation.PSCredential]
     [System.Management.Automation.Credential()]
@@ -76,13 +76,13 @@ PARAM(
 
         Write-Verbose -Message "[$FunctionName] Loading assembly System.DirectoryServices.AccountManagement"
         Add-Type -AssemblyName System.DirectoryServices.AccountManagement -ErrorAction Stop
-		
+
         # Create Context splatting
         Write-Verbose -Message "[$FunctionName] Create context splatting"
 		$ContextSplatting = @{
 			Contexttype = "Domain"
 		}
-		
+
 		IF ($PSBoundParameters['Credential']){
             Write-Verbose -Message "[$FunctionName] Context splatting - Add Credential"
             $ContextSplatting.Credential = $Credential
@@ -91,7 +91,7 @@ PARAM(
             Write-Verbose -Message "[$FunctionName] Context splatting - Add DomainName"
             $ContextSplatting.DomainName = $DomainName
         }
-        
+
         Write-Verbose -Message "[$FunctionName] Create New Principal Context using Context Splatting"
         $Context = New-ADSIPrincipalContext @ContextSplatting -ErrorAction Stop
     }
@@ -101,20 +101,21 @@ PARAM(
             # Resolving member
             # Directory Entry object
             Write-Verbose -Message "[$FunctionName] Copy Context splatting and remove ContextType property"
-			$DirectoryEntryParams = $ContextSplatting.remove('ContextType')
+            $DirectoryEntryParams = $ContextSplatting
+			$DirectoryEntryParams.remove('ContextType')
             Write-Verbose -Message "[$FunctionName] Create New Directory Entry using using the copied context"
 			$DirectoryEntry = New-ADSIDirectoryEntry @DirectoryEntryParams
-			
+
 			# Principal Searcher
             Write-Verbose -Message "[$FunctionName] Create a System.DirectoryServices.DirectorySearcher"
 			$DirectorySearcher = new-object -TypeName System.DirectoryServices.DirectorySearcher
             Write-Verbose -Message "[$FunctionName] Append DirectoryEntry to in the property SearchRoot of DirectorySearcher"
 			$DirectorySearcher.SearchRoot = $DirectoryEntry
-            
+
             # Adding an Ambiguous Name Resolution (ANR) LDAP Filter
             Write-Verbose -Message "[$FunctionName] Append LDAP Filter '(anr=$member)' to the property Filter of DirectorySearcher"
 			$DirectorySearcher.Filter = "(anr=$member)"
-            
+
             # Retrieve a single object
             Write-Verbose -Message "[$FunctionName] Retrieve the account"
             $Account = $DirectorySearcher.FindOne().GetDirectoryEntry()
@@ -132,7 +133,7 @@ PARAM(
             else{
                 Write-Error -Message "[$FunctionName] Can't retrieve the identity '$identity'"
             }
-            
+
 
             if ($pscmdlet.ShouldProcess("$Identity", "Add Account member $member")){
                 Write-Verbose -Message "[$FunctionName] Retrieve group with the identity '$identity' using Get-ADSIGroup using the Context Splatting"

--- a/AdsiPS/Public/Get-ADSIGroup.ps1
+++ b/AdsiPS/Public/Get-ADSIGroup.ps1
@@ -9,7 +9,7 @@ function Get-ADSIGroup
 
 .PARAMETER Identity
 	Specifies the Identity of the group
-	
+
 	You can provide one of the following properties
 	DistinguishedName
 	Guid
@@ -17,7 +17,7 @@ function Get-ADSIGroup
 	SamAccountName
 	Sid
 	UserPrincipalName
-	
+
 	Those properties come from the following enumeration:
 	System.DirectoryServices.AccountManagement.IdentityType
 
@@ -76,7 +76,7 @@ function Get-ADSIGroup
 .EXAMPLE
 	$Comp = Get-ADSIGroup -Identity 'Finance'
 	$Comp.GetUnderlyingObject()| select-object *
-	
+
 	Help you find all the extra properties of the Finance group object
 
 .EXAMPLE
@@ -101,7 +101,7 @@ function Get-ADSIGroup
 .LINK
 	https://msdn.microsoft.com/en-us/library/system.directoryservices.accountmanagement.groupprincipal(v=vs.110).aspx
 #>
-	
+
 	[CmdletBinding(DefaultParameterSetName = 'All')]
 	[OutputType('System.DirectoryServices.AccountManagement.GroupPrincipal')]
 	param
@@ -137,22 +137,22 @@ function Get-ADSIGroup
 
 		[Parameter(ParameterSetName = 'Filter')]
 		$SID,
-		
+
         [Parameter(ParameterSetName = 'LDAPFilter')]
         $LDAPFilter
-        
+
 	)
-	
+
 	BEGIN
 	{
 		Add-Type -AssemblyName System.DirectoryServices.AccountManagement
-		
+
 		# Create Context splatting
 		$ContextSplatting = @{ ContextType = "Domain" }
-		
+
 		IF ($PSBoundParameters['Credential']) { $ContextSplatting.Credential = $Credential }
 		IF ($PSBoundParameters['DomainName']) { $ContextSplatting.DomainName = $DomainName }
-		
+
 		$Context = New-ADSIPrincipalContext @ContextSplatting
 	}
 	PROCESS
@@ -167,17 +167,18 @@ function Get-ADSIGroup
             ELSEIF ($PSBoundParameters['LDAPFilter'])
             {
                 Write-Verbose "LDAPFilter"
-			
+
 	            # Directory Entry object
-	            $DirectoryEntryParams = $ContextSplatting.remove('ContextType')
-	            $DirectoryEntry = New-ADSIDirectoryEntry @DirectoryEntryParams
-			
+                $DirectoryEntryParams = $ContextSplatting
+                $DirectoryEntryParams.remove('ContextType')
+                $DirectoryEntry = New-ADSIDirectoryEntry @DirectoryEntryParams
+
 	            # Principal Searcher
 	            $DirectorySearcher = new-object -TypeName System.DirectoryServices.DirectorySearcher
 	            $DirectorySearcher.SearchRoot = $DirectoryEntry
 	            $DirectorySearcher.Filter = "(&(objectCategory=group)$LDAPFilter)"
 
-            
+
                 $DirectorySearcher.FindAll() | ForEach-Object {
 		            [System.DirectoryServices.AccountManagement.GroupPrincipal]::FindByIdentity($Context, ($_.path -replace 'LDAP://'))
 	            }
@@ -198,7 +199,7 @@ function Get-ADSIGroup
 				#if($PSBoundParameters['DistinguishedName']){$searcher.QueryFilter.DistinguishedName = $DistinguishedName}
 				if ($PSBoundParameters['Sid']) { $searcher.QueryFilter.Sid.Value = $SID }
 				if ($PSBoundParameters['Name']) { $searcher.QueryFilter.Name = $Name }
-				
+
 				$searcher.FindAll()
 			}
 		}

--- a/AdsiPS/Public/Remove-ADSIGroupMember.ps1
+++ b/AdsiPS/Public/Remove-ADSIGroupMember.ps1
@@ -17,7 +17,7 @@ function Remove-ADSIGroupMember
         SamAccountName
         Sid
         UserPrincipalName
-    
+
     Those properties come from the following enumeration:
         System.DirectoryServices.AccountManagement.IdentityType
 
@@ -34,7 +34,7 @@ function Remove-ADSIGroupMember
     Specifies the alternative Domain where the user should be created
     By default it will use the current domain.
 
-.EXAMPLE 
+.EXAMPLE
     Remove-ADSIGroupMember -Identity TestADSIGroup -Member 'UserTestAccount1'
 
     Removing the User account 'UserTestAccount1' to the group 'TestADSIGroup'
@@ -43,7 +43,7 @@ function Remove-ADSIGroupMember
     Remove-ADSIGroupMember -Identity TestADSIGroup -Member 'GroupTestAccount1'
 
     Removing the Group account 'GroupTestAccount1' to the group 'TestADSIGroup'
-    
+
 .EXAMPLE
     Remove-ADSIGroupMember -Identity TestADSIGroup -Member 'ComputerTestAccount1'
 
@@ -73,15 +73,15 @@ PARAM(
     BEGIN
     {
         Add-Type -AssemblyName System.DirectoryServices.AccountManagement
-		
+
         # Create Context splatting
 		$ContextSplatting = @{
 			Contexttype = "Domain"
 		}
-		
+
 		IF ($PSBoundParameters['Credential']){$ContextSplatting.Credential = $Credential}
         IF ($PSBoundParameters['DomainName']){$ContextSplatting.DomainName = $DomainName}
-        
+
         $Context = New-ADSIPrincipalContext @ContextSplatting
     }
     PROCESS
@@ -89,16 +89,17 @@ PARAM(
         TRY{
             # Resolving member
             # Directory Entry object
-			$DirectoryEntryParams = $ContextSplatting.remove('ContextType')
-			$DirectoryEntry = New-ADSIDirectoryEntry @DirectoryEntryParams
-			
+            $DirectoryEntryParams = $ContextSplatting
+            $DirectoryEntryParams.remove('ContextType')
+            $DirectoryEntry = New-ADSIDirectoryEntry @DirectoryEntryParams
+
 			# Principal Searcher
 			$DirectorySearcher = new-object -TypeName System.DirectoryServices.DirectorySearcher
 			$DirectorySearcher.SearchRoot = $DirectoryEntry
-            
+
             # Adding an Ambiguous Name Resolution LDAP Filter
 			$DirectorySearcher.Filter = "(anr=$member)"
-            
+
             # Retrieve a single object
             $Account = $DirectorySearcher.FindOne().GetDirectoryEntry()
 
@@ -111,7 +112,7 @@ PARAM(
                 'computer' {$member = [System.DirectoryServices.AccountManagement.ComputerPrincipal]::FindByIdentity($Context, $Account.distinguishedname)}
                 }
             }
-            
+
 
             if ($pscmdlet.ShouldProcess("$Identity", "Remove Account member $member")){
                 $group =(Get-ADSIGroup -Identity $Identity @ContextSplatting)

--- a/WorkInProgress/Get-ADSIObject2.ps1
+++ b/WorkInProgress/Get-ADSIObject2.ps1
@@ -24,15 +24,15 @@ PARAM(
     BEGIN
     {
         Add-Type -AssemblyName System.DirectoryServices.AccountManagement
-		
+
         # Create Context splatting
 		$ContextSplatting = @{
 			Contexttype = "Domain"
 		}
-		
+
 		IF ($PSBoundParameters['Credential']){$ContextSplatting.Credential = $Credential}
         IF ($PSBoundParameters['DomainName']){$ContextSplatting.DomainName = $DomainName}
-        
+
         $Context = New-ADSIPrincipalContext @ContextSplatting
     }
     PROCESS
@@ -40,16 +40,17 @@ PARAM(
         TRY{
             # Resolving member
             # Directory Entry object
-			$DirectoryEntryParams = $ContextSplatting.remove('ContextType')
-			$DirectoryEntry = New-ADSIDirectoryEntry @DirectoryEntryParams
-			
+            $DirectoryEntryParams = $ContextSplatting
+            $DirectoryEntryParams.remove('ContextType')
+            $DirectoryEntry = New-ADSIDirectoryEntry @DirectoryEntryParams
+
 			# Principal Searcher
 			$DirectorySearcher = new-object -TypeName System.DirectoryServices.DirectorySearcher
 			$DirectorySearcher.SearchRoot = $DirectoryEntry
-            
+
             # Adding an Ambiguous Name Resolution LDAP Filter
 			$DirectorySearcher.Filter = "(anr=$identity)"
-            
+
             # Retrieve a single object
             $Account = $DirectorySearcher.FindOne().GetDirectoryEntry()
 


### PR DESCRIPTION
Credential and DomainName params were being ignoed when using New-ADSIDirectoryEntry. The splat object was being nulled out when removing ContextType.