### PR TITLE
Fixes #43 - New-ADSIDirectoryEntry ignoring Path

### DIFF
--- a/AdsiPS/Public/New-ADSIDirectoryEntry.ps1
+++ b/AdsiPS/Public/New-ADSIDirectoryEntry.ps1
@@ -6,10 +6,10 @@
 
 .DESCRIPTION
 	Function to create a DirectoryEntry instance
-	
+
 	This function is typically a helper function used by some of the other functions
 	in the module ADSIPS
-	
+
 .PARAMETER Path
     The path of this DirectoryEntry.
     Default is $(([adsisearcher]"").Searchroot.path)
@@ -18,36 +18,36 @@
 
 .PARAMETER Credential
 	Specifies alternative credential to use
-	
+
 .PARAMETER AuthenticationType
 	Specifies the optional AuthenticationType secure flag(s) to use
-	
+
 	The Secure flag can be used in combination with other flags such as ReadonlyServer, FastBind.
-	
+
 	See the full detailed list here:
 	https://msdn.microsoft.com/en-us/library/system.directoryservices.authenticationtypes(v=vs.110).aspx
-	
+
 .EXAMPLE
 	New-ADSIDirectoryEntry
-	
+
 	Create a new DirectoryEntry object for the current domain
-	
+
 .EXAMPLE
 	New-ADSIDirectoryEntry -Path "LDAP://DC=FX,DC=lab"
-	
+
 	Create a new DirectoryEntry object for the domain FX.Lab
 
 .EXAMPLE
 	New-ADSIDirectoryEntry -Path "LDAP://DC=FX,DC=lab" -Credential (Get-Credential)
-	
+
 	Create a new DirectoryEntry object for the domain FX.Lab  with the specified credential
-	
+
 .LINK
     https://msdn.microsoft.com/en-us/library/system.directoryservices.directoryentry.aspx
 
 .LINK
     http://www.lazywinadmin.com/2013/10/powershell-using-adsi-with-alternate.html
-	
+
 .NOTES
     Francois-Xavier Cat
 	www.lazywinadmin.com
@@ -56,27 +56,32 @@
 #>
 	[CmdletBinding(SupportsShouldProcess = $true)]
 	PARAM (
+		[Alias('DomainName')]
 		$Path = $(([adsisearcher]"").Searchroot.path),
 
 		[Alias("RunAs")]
 		[System.Management.Automation.PSCredential]
 		[System.Management.Automation.Credential()]
 		$Credential = [System.Management.Automation.PSCredential]::Empty,
-		
+
 		[System.DirectoryServices.AuthenticationTypes[]]$AuthenticationType
 	)
 	TRY{
 		#Building Argument
-		IF ($PSBoundParameters['Credential'])
+		If ($PSBoundParameters['Credential'])
 		{
 			$ArgumentList = $Path, $($Credential.UserName), $($Credential.GetNetworkCredential().password)
 		}
-		
+		else
+		{
+			$ArgumentList = $Path
+		}
+
 		IF ($PSBoundParameters['AuthenticationType'])
 		{
 			$ArgumentList += $AuthenticationType
 		}
-		
+
 		IF ($PSCmdlet.ShouldProcess($Path, "Create Directory Entry"))
 		{
 			# Create object


### PR DESCRIPTION
Fixes #43
* Adds Path to Argumentlist if Credentials aren't suppied. 
* Add Alias for DomainName to Path since ContextSplatting might be used for Path.