### PR TITLE
Fixes when using LDAPFilter, when setting/using passwords, DomainName parameter additions

### DIFF
--- a/AdsiPS/Public/Get-ADSIUser.ps1
+++ b/AdsiPS/Public/Get-ADSIUser.ps1
@@ -155,7 +155,7 @@ function Get-ADSIUser
             }
 
             $DirectorySearcher.FindAll() | ForEach-Object {
-				[System.DirectoryServices.AccountManagement.UserPrincipal]::FindByIdentity($Context, ($_.path -replace 'LDAP://'))
+				[System.DirectoryServices.AccountManagement.UserPrincipal]::FindByIdentity($Context, $_.Properties["distinguishedname"])
 			}# Return UserPrincipale object
 		}
 		ELSE

--- a/AdsiPS/Public/New-ADSIDirectoryEntry.ps1
+++ b/AdsiPS/Public/New-ADSIDirectoryEntry.ps1
@@ -67,6 +67,15 @@
 		[System.DirectoryServices.AuthenticationTypes[]]$AuthenticationType
 	)
 	TRY{
+		#If path isn't prefixed with LDAP://, add it
+		If ($PSBoundParameters['Path'])
+		{
+			if($Path -notlike "^LDAP")
+			{
+				$Path = "LDAP://$Path"
+			}
+		}
+		
 		#Building Argument
 		If ($PSBoundParameters['Credential'])
 		{

--- a/AdsiPS/Public/New-ADSIUser.ps1
+++ b/AdsiPS/Public/New-ADSIUser.ps1
@@ -147,7 +147,7 @@
 				IF ($PSBoundParameters['HomeDrive']) { $user.HomeDrive = $HomeDrive }
 				IF ($PSBoundParameters['MiddleName']) { $user.MiddleName = $MiddleName }
 				IF ($PSBoundParameters['VoiceTelephoneNumber']) { $user.VoiceTelephoneNumber }
-				IF ($PSBoundParameters['AccountPassword']){$User.SetPassword($AccountPassword)}
+				IF ($PSBoundParameters['AccountPassword']){$User.SetPassword((New-Object PSCredential "user",$AccountPassword).GetNetworkCredential().Password)}
 				
 				Write-Verbose -message "Create the Account in Active Directory"
 				$User.Save($Context)

--- a/AdsiPS/Public/Set-ADSIUserPassword.ps1
+++ b/AdsiPS/Public/Set-ADSIUserPassword.ps1
@@ -68,7 +68,7 @@
 		{
 			if ($pscmdlet.ShouldProcess("$Identity", "Change Account Password"))
 			{
-				(Get-ADSIUser -Identity $Identity @ContextSplatting).SetPassword("$AccountPassword")
+				(Get-ADSIUser -Identity $Identity @ContextSplatting).SetPassword((New-Object PSCredential "user",$AccountPassword).GetNetworkCredential().Password)
 			}
 		}
 		CATCH

--- a/AdsiPS/Public/Test-ADSICredential.ps1
+++ b/AdsiPS/Public/Test-ADSICredential.ps1
@@ -13,6 +13,14 @@ function Test-ADSICredential
 .PARAMETER AccountPassword
 	Specifies the AccountName's password
 
+.PARAMETER Credential
+	Specifies the alternative credential to use.
+	By default it will use the current user windows credentials.
+
+.PARAMETER DomainName
+	Specifies the alternative Domain where the user should be created
+	By default it will use the current domain.
+
 .EXAMPLE
 	Test-ADCredential -AccountName 'Xavier' -Password 'Wine and Cheese!'
 

--- a/AdsiPS/Public/Unlock-ADSIUser.ps1
+++ b/AdsiPS/Public/Unlock-ADSIUser.ps1
@@ -19,6 +19,10 @@ function Unlock-ADSIUser
 .EXAMPLE
 	Unlock-ADSIUser -Identity 'testaccount' -Credential (Get-Credential)
 
+.PARAMETER DomainName
+	Specifies the alternative Domain where the user should be created
+	By default it will use the current domain.
+
 .NOTES
 	Francois-Xavier Cat
 	lazywinadmin.com
@@ -32,11 +36,20 @@ function Unlock-ADSIUser
 		[Alias("RunAs")]
 		[System.Management.Automation.PSCredential]
 		[System.Management.Automation.Credential()]
-		$Credential = [System.Management.Automation.PSCredential]::Empty
-	)
+		$Credential = [System.Management.Automation.PSCredential]::Empty,
+		
+		[String]$DomainName)
+	BEGIN
+	{
+		Add-Type -AssemblyName System.DirectoryServices.AccountManagement
+		
+		# Create Context splatting
+		$ContextSplatting = @{ }
+		IF ($PSBoundParameters['Credential']) { $ContextSplatting.Credential = $Credential }
+		IF ($PSBoundParameters['DomainName']) { $ContextSplatting.DomainName = $DomainName }
+	}
 	PROCESS
 	{
-		
-		(Get-ADSIUser @PSBoundParameters).UnlockAccount()
+		(Get-ADSIUser -Identity $Identity @ContextSplatting).UnlockAccount()
 	}
 }


### PR DESCRIPTION
`Get-ADSIUser`
When using the LDAPFilter, use the distinguishedname property from the SearchResult object

`New-ADSIDirectoryEntry`
If Path is missing the LDAP:// prefix, add it

`New-ADSIUser`, `Set-ADSIUserPassword`, `Test-ADSICredential`
Fix the conversion of SecureString to String when passing passwords into methods that only accept Strings (password was getting set to "System.Security.SecureString")

`Test-ADSICredential`, `Unlock-ADSIUser`
Add DomainName and Credential parameters