### PR TITLE
Fix Path notlike pattern

### DIFF
--- a/AdsiPS/Public/New-ADSIDirectoryEntry.ps1
+++ b/AdsiPS/Public/New-ADSIDirectoryEntry.ps1
@@ -70,7 +70,7 @@
 		#If path isn't prefixed with LDAP://, add it
 		If ($PSBoundParameters['Path'])
 		{
-			if($Path -notlike "^LDAP")
+			if($Path -notlike "LDAP://*")
 			{
 				$Path = "LDAP://$Path"
 			}


### PR DESCRIPTION
-notlike  replace regex ^LDAP by pattern LDAP://* 
Another option :  replace - notlike by -notmatch, but  ^LDAP regex don't check error in LDAP:// format. exemple : LDAPO:// is OK with  ^LDAP
