### PR TITLE
Get-ADSIPrincipalGroupMembership Change Proposal

### DIFF
--- a/AdsiPS/Public/Get-ADSIPrincipalGroupMembership.ps1
+++ b/AdsiPS/Public/Get-ADSIPrincipalGroupMembership.ps1
@@ -24,7 +24,7 @@ Function Get-ADSIPrincipalGroupMembership
     Type System.DirectoryServices.AccountManagement.AuthenticablePrincipal
 
 .PARAMETER GroupInfos
-    UserInfos is a GroupPrincipal object.
+    GroupInfos is a GroupPrincipal object.
     Type System.DirectoryServices.AccountManagement.Principal
 
 .PARAMETER Credential
@@ -120,17 +120,14 @@ Function Get-ADSIPrincipalGroupMembership
                 } else {
                     
                     $ObjectSplatting  = @{}
-                    $ContextSplatting = @{}
 
                     if ($PSBoundParameters["DomainName"]) {                        
-                        $ContextSplatting.DomainName = $DomainName
                         # Turn Domain Name into DN
                         $ObjectSplatting.DomainDistinguishedName = ($DomainName.Split(".").ForEach({ "DC=$($_)," }) -join '').TrimEnd(',')                        
                     }
 
                     if ($PSBoundParameters["Credential"]) {
                         $ObjectSplatting.Credential  = $Credential
-                        $ContextSplatting.Credential = $Credential
                     }
                                     
                     $FoundObject = $null

--- a/AdsiPS/Public/Get-ADSIPrincipalGroupMembership.ps1
+++ b/AdsiPS/Public/Get-ADSIPrincipalGroupMembership.ps1
@@ -23,43 +23,55 @@ Function Get-ADSIPrincipalGroupMembership
     UserInfos is a UserPrincipal object.
     Type System.DirectoryServices.AccountManagement.AuthenticablePrincipal
 
+.PARAMETER GroupInfos
+    UserInfos is a GroupPrincipal object.
+    Type System.DirectoryServices.AccountManagement.Principal
+
 .PARAMETER Credential
     Specifies the alternative credential to use.
-
     By default it will use the current user windows credentials.
 
 .PARAMETER DomainName
     Specifies the alternative Domain where the user should be created
-
     By default it will use the current domain.
 
 .PARAMETER NoResultLimit
     Remove the SizeLimit of 1000
-
     SizeLimit is useless, it can't go over the server limit which is 1000 by default
 
 .EXAMPLE
     Get-ADSIPrincipalGroupMembership -Identity 'User1'
-
     Get all AD groups of user User1
 
 .EXAMPLE
     Get-ADSIPrincipalGroupMembership -Identity 'User1' -Credential (Get-Credential)
-
     Use a different credential to perform the query
 
 .EXAMPLE
     Get-ADSIPrincipalGroupMembership -Identity 'User1' -DomainName "CONTOSO.local"
-
     Use a different domain name to perform the query
 
 .EXAMPLE
-    Get-ADSIPrincipalGroupMembership -Identity 'User1' -DomainDistinguishedName 'DC=CONTOSO,DC=local'
+    Get-ADSIPrincipalGroupMembership -Identity 'Group1'
+    Get all AD groups of group Group1
 
+.EXAMPLE
+    Get-ADSIPrincipalGroupMembership -Identity 'Group1' -Credential (Get-Credential)
+    Use a different credential to perform the query
+
+.EXAMPLE
+    Get-ADSIPrincipalGroupMembership -Identity 'Group1' -DomainName "CONTOSO.local"
+    Use a different domain name to perform the query
+
+.EXAMPLE *** this is incorrect ***
+    Get-ADSIPrincipalGroupMembership -Identity 'User1' -DomainDistinguishedName 'DC=CONTOSO,DC=local'
     Use a different domain distinguished name to perform the query
 
 .NOTES
     https://github.com/lazywinadmin/ADSIPS
+
+.NOTES (5/22/2019)
+    [Matthew Oestreich]::Info(https://mattoestrei.ch, https://github.com/oze4, matthewpoestreich@gmail.com)
 #>
     [CmdletBinding()]
     param
@@ -68,15 +80,10 @@ Function Get-ADSIPrincipalGroupMembership
         [string]$Identity,
 
         [Parameter(Mandatory = $true, ParameterSetName = "UserInfos")]
-        [ValidateScript( { if ($_.GetType().Name -eq 'UserPrincipal')
-                {
-                    $true
-                }
-                else
-                {
-                    throw ('UserInfos must be a UserPrincipal type System.DirectoryServices.AccountManagement.AuthenticablePrincipal')
-                } })]
-        $UserInfos,
+        [System.DirectoryServices.AccountManagement.AuthenticablePrincipal]$UserInfos,
+
+        [Parameter(Mandatory = $true, ParameterSetName = "GroupInfos")]
+        [System.DirectoryServices.AccountManagement.Principal]$GroupInfos,
 
         [Alias("RunAs")]
         [System.Management.Automation.PSCredential]
@@ -92,64 +99,95 @@ Function Get-ADSIPrincipalGroupMembership
 
     begin
     {
-        # Create Context splatting
-        $ContextSplatting = @{}
 
-        if ($PSBoundParameters['Credential'])
+        switch($PSBoundParameters.Keys)
         {
-            $ContextSplatting.Credential = $Credential
-        }
-        if ($PSBoundParameters['DomainName'])
-        {
-            $ContextSplatting.DomainName = $DomainName
-        }
-        if ($PSBoundParameters['NoResultLimit'])
-        {
-            $ContextSplatting.NoResultLimit = $true
+            'UserInfos'  { 
+                $UnderlyingProperties = $UserInfos.GetUnderlyingObject() 
+            }
+
+            'GroupInfos' {
+                $UnderlyingProperties = $GroupInfos.GetUnderlyingObject()
+            }
+            
+            'Identity'   {
+
+                # If the user supplies a GroupPrincipal or UserPrincipal under the 'Identity' parameter
+                if (($Identity.GetType().Name -eq "GroupPrincipal") -or ($Identity.GetType().Name -eq "UserPrincipal")) {
+                                                
+                    $UnderlyingProperties = $Identity.GetUnderlyingObject()                
+
+                } else {
+                    
+                    $ObjectSplatting  = @{}
+                    $ContextSplatting = @{}
+
+                    if ($PSBoundParameters["DomainName"]) {                        
+                        $ContextSplatting.DomainName = $DomainName
+                        # Turn Domain Name into DN
+                        $ObjectSplatting.DomainDistinguishedName = ($DomainName.Split(".").ForEach({ "DC=$($_)," }) -join '').TrimEnd(',')                        
+                    }
+
+                    if ($PSBoundParameters["Credential"]) {
+                        $ObjectSplatting.Credential  = $Credential
+                        $ContextSplatting.Credential = $Credential
+                    }
+                                    
+                    $FoundObject = $null
+                    # Get the ADSIObject for what we were provided
+                    foreach($IdType in [System.DirectoryServices.AccountManagement.IdentityType].GetEnumNames()) {                        
+                        $splat = @{ 
+                            $IdType = $Identity
+                        }                        
+                        
+                        try { 
+                            $FoundObject = Get-ADSIObject @splat @ObjectSplatting
+                        } catch {
+                            # do nothing, only here to suppress errors
+                        } 
+                        
+                        if ($FoundObject -ne $null) { 
+                            $FoundObjectObjectClass = $FoundObject.objectclass.Split(" ")
+                            break; 
+                        }
+                    }
+
+                    if ($FoundObjectObjectClass -contains "person" -or $FoundObjectObjectClass -contains "user") {
+                        $UserInfos = Get-ADSIUser -Identity $FoundObject.samaccountName
+                        $UnderlyingProperties = $UserInfos.GetUnderlyingObject()
+                    }
+
+                    if ($FoundObjectObjectClass -contains "group") {
+                        $GroupInfos = Get-ADSIGroup -Identity $FoundObject.samaccountName
+                        $UnderlyingProperties = $GroupInfos.GetUnderlyingObject()
+                    }
+                }
+            }
         }
     }
     process
     {
-        $Usergroups = $null
 
-        if ($PSBoundParameters['UserInfos'])
+        # I didn't understand the point in wasting that IO to get Primary Group, when nothing special was done with it.  
+        # Getting groups using only the code below returns the same groups with or without the "Get Primary Group" code.
+        # In the return of this function, the Primary Group was not returned any different than a regular group.
+
+        $ObjectGroups   = @()        
+        $Objectmemberof = $UnderlyingProperties.memberOf
+
+        if ($Objectmemberof)
         {
-            $UserInfosMoreProperties = $UserInfos.GetUnderlyingObject()
-        }
-        else
-        {
-            $UserInfos = Get-ADSIUser -Identity $Identity @ContextSplatting
-            $UserInfosMoreProperties = $UserInfos.GetUnderlyingObject()
-        }
-
-        $Usergroups = @()
-
-        #Get Primary group
-        $SID = New-Object -TypeName System.Security.Principal.SecurityIdentifier -ArgumentList ($($UserInfosMoreProperties.properties.Item('objectSID')), 0)
-        $groupSID = ('{0}-{1}' -f $SID.AccountDomainSid.Value, [string]$UserInfosMoreProperties.properties.Item('primarygroupid'))
-        $group = [adsi]("LDAP://<SID=$groupSID>")
-
-
-        $Usergroups += [pscustomobject]@{
-            'name'        = [string]$group.name
-            'description' = [string]$group.description
-        }
-
-        #Get others groups
-        $Usermemberof = $UserInfosMoreProperties.memberOf
-
-        if ($Usermemberof)
-        {
-            foreach ($item in $Usermemberof)
+            foreach ($item in $Objectmemberof)
             {
-                $ADSIusergroup = [adsi]"LDAP://$item"
+                $ADSIobjectgroup = [adsi]"LDAP://$item"
 
-                $Usergroups += [pscustomobject]@{
-                    'name'        = [string]$ADSIusergroup.Properties.name
-                    'description' = [string]$ADSIusergroup.Properties.description
+                $ObjectGroups += [pscustomobject]@{
+                    'name'        = [string]$ADSIobjectgroup.Properties.name
+                    'description' = [string]$ADSIobjectgroup.Properties.description
                 }
             }
         }
-        $Usergroups
+        
+        $ObjectGroups
     }
 }

--- a/AdsiPS/Public/Get-ADSIPrincipalGroupMembership.ps1
+++ b/AdsiPS/Public/Get-ADSIPrincipalGroupMembership.ps1
@@ -21,57 +21,66 @@ Function Get-ADSIPrincipalGroupMembership
 
 .PARAMETER UserInfos
     UserInfos is a UserPrincipal object.
+
     Type System.DirectoryServices.AccountManagement.AuthenticablePrincipal
 
 .PARAMETER GroupInfos
     GroupInfos is a GroupPrincipal object.
+
     Type System.DirectoryServices.AccountManagement.Principal
 
 .PARAMETER Credential
     Specifies the alternative credential to use.
+
     By default it will use the current user windows credentials.
 
 .PARAMETER DomainName
     Specifies the alternative Domain where the user should be created
+
     By default it will use the current domain.
 
 .PARAMETER NoResultLimit
     Remove the SizeLimit of 1000
+
     SizeLimit is useless, it can't go over the server limit which is 1000 by default
 
 .EXAMPLE
     Get-ADSIPrincipalGroupMembership -Identity 'User1'
+
     Get all AD groups of user User1
 
 .EXAMPLE
     Get-ADSIPrincipalGroupMembership -Identity 'User1' -Credential (Get-Credential)
+
     Use a different credential to perform the query
 
 .EXAMPLE
     Get-ADSIPrincipalGroupMembership -Identity 'User1' -DomainName "CONTOSO.local"
+
     Use a different domain name to perform the query
 
 .EXAMPLE
     Get-ADSIPrincipalGroupMembership -Identity 'Group1'
+
     Get all AD groups of group Group1
 
 .EXAMPLE
     Get-ADSIPrincipalGroupMembership -Identity 'Group1' -Credential (Get-Credential)
+
     Use a different credential to perform the query
 
 .EXAMPLE
     Get-ADSIPrincipalGroupMembership -Identity 'Group1' -DomainName "CONTOSO.local"
+
     Use a different domain name to perform the query
 
-.EXAMPLE *** this is incorrect ***
+.EXAMPLE
     Get-ADSIPrincipalGroupMembership -Identity 'User1' -DomainDistinguishedName 'DC=CONTOSO,DC=local'
+
     Use a different domain distinguished name to perform the query
 
 .NOTES
     https://github.com/lazywinadmin/ADSIPS
-
-.NOTES (5/22/2019)
-    [Matthew Oestreich]::Info(https://mattoestrei.ch, https://github.com/oze4, matthewpoestreich@gmail.com)
 #>
     [CmdletBinding()]
     param


### PR DESCRIPTION
Proposals:

  - Run `Add-Type -AssemblyName System.DirectoryServices.AccountManagement` during module import
  - Currently you have to manually import that assembly in order for `Get-ADSIGroup` to work (to reproduce, import this module in a clean session, then run `Get-ADSIGroup` - it will not work until you add the above assembly - I would consider this to be a bug)
  - Modify `Get-ADSIPrincipalGroupMembership` to allow people to search for Groups as well as User Group Membership (I have already made the necessary changes for this, see below for more info)

While using this excellent module, I noticed I was not able to get the Group Membership of an actual Group - it only allowed for users.  I have added that functionality to this script, and tested that it is working (I have also replaced this script in my local ADSIPs module)..

The following changes were made:

  - Added the ability to provide a Group within the `-Identity` parameter (you can use the same 6 attributes to search for a user, just like you can when searching for a User:  "DistinguishedName", "Guid", "Name", "SamAccountName", "Sid", -"UserPrincipalName"
  - Added a parameter for `-GroupInfos` that acts just like `-UserInfos`, but it is specific to Groups
  - Ensured you can still pass `-DomainName`, as well as `-Credentials` along with `-Identity`
  - Removed `-NoResultLimit`, as this is pointless per the comment block
  - Cleaned up parameter type validation
  - Cleaned up some redundant code
  - Cleaned up the `begin` block

I have verified this is working (even on a trusted domain, not in the same forest)..

Overall, this adds a lot of flexibility to this function.