### PR TITLE
CONTRIBUTING.md, README.md, build.ps1, Set-ADSIUser.ps1, Get-ADSIUser (issue #72)

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -29,7 +29,9 @@ Write-Verbose -Message "[$ScriptName] Querying system X"
 
 * [ ] Pick one of the issues
 * [ ] Add more Pester test
-* [ ] Integrate with CI/CD (Appveyor) for auto publish to gallery
+* [x] Integrate with CI/CD (Appveyor) for auto publish to gallery
+  - **NOTE:** have since migrated to Azure Pipelines
+* [x] Migrate to Azure Pipelines
 * [ ] Update documentation, possibly add support for [ReadTheDocs](http://docs.readthedocs.io/en/latest/index.html) to help Adoption
 * [ ] Set-ADSIComputer
 * [ ] Set-ADSIGroup (also with -ManagedBy, and -ManagerCanUpdateMembership [example](https://blogs.technet.microsoft.com/blur-lines_-powershell_-author_shirleym/2013/10/07/manager-can-update-membership-list-part-1/))

--- a/README.md
+++ b/README.md
@@ -39,6 +39,8 @@ Install-Module -name ADSIPS
 1. Download the repository
 1. Unblock the zip file
 1. Extract the folder to a module path (e.g. $home\Documents\WindowsPowerShell\Modules)
+1. Run `build.ps1` (exists in project root)
+  - **NOTE:** If you get an error after running `build.ps1` - please use **`build.ps1 -InstallDependencies`**
 
 ## Use Cases
 

--- a/README.md
+++ b/README.md
@@ -26,7 +26,7 @@ Please see our [contributing guide](https://github.com/lazywinadmin/adsips/blob/
 
 ## Installation
 
-### Download from PowerShell Gallery
+### Download from PowerShell Gallery (recommended)
 
 Only from PowerShell version 5
 
@@ -34,13 +34,16 @@ Only from PowerShell version 5
 Install-Module -name ADSIPS
 ```
 
-### Download from GitHub repository
+### Download from GitHub repository 
 
 1. Download the repository
 1. Unblock the zip file
 1. Extract the folder to a module path (e.g. $home\Documents\WindowsPowerShell\Modules)
 1. Run `build.ps1` (exists in project root)
   - **NOTE:** If you get an error after running `build.ps1` - please use **`build.ps1 -InstallDependencies`**
+1. `build.ps1` creates a folder called `~\buildoutput\AdsiPs` in the directory which `AdsiPs` was saved to
+1. Inside of `\buildoutput\AdsiPs` there is a file called `AdsiPs.psm1`
+1. Run `Import-Module -Path "C:\Path\To\buildoutput\AdsiPs\AdsiPs.psm1"` to import the `AdsiPs` module
 
 ## Use Cases
 

--- a/build.ps1
+++ b/build.ps1
@@ -11,6 +11,8 @@ Change History
     - Added specific error handling/error message in regards to missing dependencies and how to resolve them
     - Specifically, to use the `-InstallDependencies` switch with `build.ps1`
     - Removed redundant `[string[]]$tasks` parameter.. (param appears to be in use, but there was a duplicate, which was commented out, so I just removed it)
+    - Added 'tasks' param check so if user wants to build this locally, they don't have to know to supply the 'tasks' param with a value of @('build')
+        - TODO: rewrite this using switch params
 #>
 [CmdletBinding()]
 Param(
@@ -21,6 +23,11 @@ Param(
     [switch]$InstallDependencies
     )
 try{
+    #  Added so if user wants to build this locally, they don't have to know to supply the 'tasks' param with a value of @('build')
+    #  - 2019/06/22 | Matt Oestreich (oze4)
+    if ($tasks.count -eq 0) { 
+        $tasks = @("build") 
+    }
     ################
     # EDIT THIS PART
     $moduleName = "AdsiPS" # get from source control or module ?

--- a/build.ps1
+++ b/build.ps1
@@ -7,6 +7,9 @@ This script will install dependencies using PSDepend module and start the build 
 Change History
 -1.0 | 2019/06/17 | Francois-Xavier Cat
     Initial version
+-1.1 | 2019/06/22 | Matt Oestreich (oze4)
+    - Added specific error handling/error message in regards to missing dependencies and how to resolve them
+    - Specifically, to use the `-InstallDependencies` switch with `build.ps1`
 #>
 [CmdletBinding()]
 Param(
@@ -90,7 +93,15 @@ try{
 
     # Start build using InvokeBuild module
     Write-Verbose -Message "Start Build"
-    Invoke-Build -Result 'Result' -File $buildTasksFilePath -Task $tasks
+    try {
+        Invoke-Build -Result 'Result' -File $buildTasksFilePath -Task $tasks
+    } catch {
+        #  During testing, this was an issue for me.. 
+        #  Just wanting to clarify a possible solution to make things easier on people that use this module
+        #  June 22, 2019 - Matt Oestreich (oze4)
+        $missingDependenciesError = "[ERROR build.ps1] It is possible you are missing dependencies. Please rerun using 'build.ps1 -InstallDependencies' if you do not have the 'PSDepend' module installed!"
+        throw New-Object System.Exception ($missingDependenciesError)
+    }
 
     # Return error to CI
     if ($Result.Error)

--- a/build.ps1
+++ b/build.ps1
@@ -10,10 +10,10 @@ Change History
 -1.1 | 2019/06/22 | Matt Oestreich (oze4)
     - Added specific error handling/error message in regards to missing dependencies and how to resolve them
     - Specifically, to use the `-InstallDependencies` switch with `build.ps1`
+    - Removed redundant `[string[]]$tasks` parameter.. (param appears to be in use, but there was a duplicate, which was commented out, so I just removed it)
 #>
 [CmdletBinding()]
 Param(
-    #[string[]]$tasks,
     [string]$GalleryRepository,
     [pscredential]$GalleryCredential,
     [string]$GalleryProxy,

--- a/src/public/Get-ADSIUser.ps1
+++ b/src/public/Get-ADSIUser.ps1
@@ -71,6 +71,16 @@ function Get-ADSIUser
 
 .NOTES
     https://github.com/lazywinadmin/ADSIPS
+    ----------------
+    CHANGE HISTORY
+    ----------------
+    -0.1 | 2019/06/22 | Matt Oestreich (oze4)
+        - Added Change History section to comments
+        - Resolving issue #72: https://github.com/lazywinadmin/AdsiPS/issues/72
+        - Resolution has been tested and verified (can still add '-Domain' or '-Credential' params if need be)
+        - No longer have to specify `-Identity` param explicitly, now able to supply only a value
+            - ex: (no longer have to do this) Get-ADSIUser -Identity 'Some.Name'
+            - ex: (now you can simply do)     Get-ADSIUser 'Some.Name'
 
 .LINK
     https://msdn.microsoft.com/en-us/library/System.DirectoryServices.AccountManagement.UserPrincipal(v=vs.110).aspx
@@ -80,7 +90,7 @@ function Get-ADSIUser
     [OutputType('System.DirectoryServices.AccountManagement.UserPrincipal')]
     param
     (
-        [Parameter(Mandatory = $true, ParameterSetName = "Identity")]
+        [Parameter(Mandatory = $true, Position = 0, ParameterSetName = "Identity")]
         [string]$Identity,
 
         [Alias("RunAs")]

--- a/src/public/Set-ADSIUser.ps1
+++ b/src/public/Set-ADSIUser.ps1
@@ -1,4 +1,4 @@
-﻿function Set-ADSIUser
+function Set-ADSIUser
 {
 <#
 .SYNOPSIS
@@ -43,6 +43,12 @@
 .PARAMETER UserPrincipalName
     Specify the UserPrincipalName. This parameter sets the UserPrincipalName property of a user.
 
+.PARAMETER HomeDrive
+    Specify the HomeDrive. This parameter sets the HomeDrive property of a user. This must be a single letter (aka 'U'). This is the drive you want the HomeDirectory to show up as
+
+.PARAMETER HomeDirectory
+    Specify the HomeDirectory. This parameter sets the HomeDirectory property of a user. This is the directory you want to map to.
+
 .PARAMETER TelephoneNumber
     Specify the Telephone number
 
@@ -65,7 +71,7 @@
 .NOTES
     https://github.com/lazywinadmin/ADSIPS
 #>
-    [CmdletBinding(SupportsShouldProcess = $true, ConfirmImpact = 'High')]
+    [CmdletBinding(SupportsShouldProcess = $true, ConfirmImpact = 'High', DefaultParameterSetName = 'Default')]
     param (
         [Parameter(Mandatory = $true)]
         [String]$Identity,
@@ -99,6 +105,14 @@
 
         [Parameter(Mandatory = $false)]
         [string]$UserPrincipalName,
+
+        [Parameter(Mandatory = $false)]         
+        [Parameter(Mandatory = $true, ParameterSetName = "HomeDriveHomeDirectory")]
+        [string]$HomeDrive,
+
+        [Parameter(Mandatory = $false)] 
+        [Parameter(Mandatory = $true, ParameterSetName = "HomeDriveHomeDirectory")]
+        [string]$HomeDirectory,
 
         [Alias("Domain", "DomainDN")]
         [String]$DomainName = $(([adsisearcher]"").Searchroot.path),
@@ -176,8 +190,8 @@
                         }
                         else
                         {
-                            $Adspath.Put("co", $Country)
-                            $Adspath.SetInfo()
+                            $adspath.Put("co", $Country)
+                            $adspath.SetInfo()
                         }
                     }
                 }
@@ -351,6 +365,42 @@
                         {
                             $Adspath.Put("UserPrincipalName", $UserPrincipalName)
                             $Adspath.SetInfo()
+                        }
+                    }
+                }
+
+                # HomeDrive
+                if ($HomeDrive -ne '')
+                {
+                    if($HomeDrive.Length -gt 1) {
+         
+                        $e = New-Object System.Exception "[Set-AdsiUser] HomeDrive must be a single letter!"
+                        throw $e
+
+                    } elseif($HomeDirectory -eq '') {
+
+                        $er = New-Object System.Exception "[Set-AdsiUser] HomeDirectory must be use with HomeDrive! HomeDrive is the drive letter, HomeDirectory is the path."
+                        throw $er      
+                                       
+                    } else {
+                        Write-Verbose -Message "[$($Account)] Setting HomeDrive value to : $HomeDrive and HomeDirectory to : $HomeDirectory"
+
+                        if ($PSCmdlet.ShouldProcess($env:COMPUTERNAME, "Set HomeDrive of account $account to $HomeDrive and HomeDirectory to $HomeDirectory"))
+                        {
+                            if ($PSBoundParameters.ContainsKey('WhatIf'))
+                            {
+                                Write-Verbose -Message "WhatIf: Setting HomeDrive of account $account to $HomeDrive and HomeDirectory to $HomeDirectory" -Verbose:$true
+                            }
+                            else
+                            {
+                                try {
+                                    $Adspath.Put("homeDrive", $HomeDrive)
+                                    $adspath.Put("homeDirectory", $HomeDirectory)
+                                    $Adspath.SetInfo()
+                                } catch {
+                                    throw $_
+                                }
+                            }
                         }
                     }
                 }


### PR DESCRIPTION
## The following changes have been made

- ### README.md
  - Added instructions on how to build this module if you download it locally vs using Nuget
- ### CONTRIBUTING.md
  - Updated AppVeyor to Azure Pipelines migration
- ### build.ps1
  - Added more specific error handling/error message for missing dependencies
  - Updated Change History (more detailed info can be found there)
- ### Set-ADSIUser.ps1
  - Added ability to set user HomeDrive and HomeDirectory
  - Updated documentation
- ### Get-ADSIUser.ps1
  - Fix for issue #72 