### PR TITLE
Bug Fix, Formatting Fix, Addition of Get-ADSIUserPrimaryGroup

### DIFF
--- a/README.md
+++ b/README.md
@@ -37,13 +37,13 @@ Install-Module -name ADSIPS
 ### Download from GitHub repository 
 
 1. Download the repository
-1. Unblock the zip file
-1. Extract the folder to a module path (e.g. $home\Documents\WindowsPowerShell\Modules)
-1. Run `build.ps1` (exists in project root)
+2. Unblock the zip file
+3. Extract the folder to a module path (e.g. $home\Documents\WindowsPowerShell\Modules)
+4. Run `build.ps1` (exists in project root)
   - **NOTE:** If you get an error after running `build.ps1` - please use **`build.ps1 -InstallDependencies`**
-1. `build.ps1` creates a folder called `~\buildoutput\AdsiPs` in the directory which `AdsiPs` was saved to
-1. Inside of `\buildoutput\AdsiPs` there is a file called `AdsiPs.psm1`
-1. Run `Import-Module -Path "C:\Path\To\buildoutput\AdsiPs\AdsiPs.psm1"` to import the `AdsiPs` module
+5. `build.ps1` creates a folder called `~\buildoutput\AdsiPs` in the directory which `AdsiPs` was saved to
+6. Inside of `\buildoutput\AdsiPs` there is a file called `AdsiPs.psm1`
+7. Run `Import-Module -Path "C:\Path\To\buildoutput\AdsiPs\AdsiPs.psm1"` to import the `AdsiPs` module
 
 ## Use Cases
 

--- a/build.ps1
+++ b/build.ps1
@@ -25,7 +25,7 @@ Param(
 try{
     #  Added so if user wants to build this locally, they don't have to know to supply the 'tasks' param with a value of @('build')
     #  - 2019/06/22 | Matt Oestreich (oze4)
-    if ($tasks.count -eq 0) { 
+    if (-not $tasks) { 
         $tasks = @("build") 
     }
     ################

--- a/src/public/Get-ADSIPrincipalGroupMembership.ps1
+++ b/src/public/Get-ADSIPrincipalGroupMembership.ps1
@@ -1,97 +1,102 @@
 Function Get-ADSIPrincipalGroupMembership
-{
+{ 
     <#
-.SYNOPSIS
-    Function to retrieve groups from a user in Active Directory
+            .SYNOPSIS
+            Function to retrieve groups from a user in Active Directory
 
-.DESCRIPTION
-    Get all AD groups of a user, primary one and others
+            .DESCRIPTION
+            Get all AD groups of a user, primary one and others
 
-.PARAMETER Identity
-    Specifies the Identity of the User
-    You can provide one of the following properties
-    DistinguishedName
-    Guid
-    Name
-    SamAccountName
-    Sid
-    UserPrincipalName
-    Those properties come from the following enumeration:
-    System.DirectoryServices.AccountManagement.IdentityType
+            .PARAMETER Identity
+            Specifies the Identity of the User
+            You can provide one of the following properties
+            DistinguishedName
+            Guid
+            Name
+            SamAccountName
+            Sid
+            UserPrincipalName
+            Those properties come from the following enumeration:
+            System.DirectoryServices.AccountManagement.IdentityType
 
-.PARAMETER UserInfos
-    UserInfos is a UserPrincipal object.
+            .PARAMETER UserInfos
+            UserInfos is a UserPrincipal object.
 
-    Type System.DirectoryServices.AccountManagement.AuthenticablePrincipal
+            Type System.DirectoryServices.AccountManagement.AuthenticablePrincipal
 
-.PARAMETER GroupInfos
-    GroupInfos is a GroupPrincipal object.
+            .PARAMETER GroupInfos
+            GroupInfos is a GroupPrincipal object.
 
-    Type System.DirectoryServices.AccountManagement.Principal
+            Type System.DirectoryServices.AccountManagement.Principal
 
-.PARAMETER Credential
-    Specifies the alternative credential to use.
+            .PARAMETER Credential
+            Specifies the alternative credential to use.
 
-    By default it will use the current user windows credentials.
+            By default it will use the current user windows credentials.
 
-.PARAMETER DomainName
-    Specifies the alternative Domain where the user should be created
+            .PARAMETER DomainName
+            Specifies the alternative Domain where the user should be created
 
-    By default it will use the current domain.
+            By default it will use the current domain.
 
-.EXAMPLE
-    Get-ADSIPrincipalGroupMembership -Identity 'User1'
+            .EXAMPLE
+            Get-ADSIPrincipalGroupMembership -Identity 'User1'
 
-    Get all AD groups of user User1
+            Get all AD groups of user User1
 
-.EXAMPLE
-    Get-ADSIPrincipalGroupMembership -Identity 'User1' -Credential (Get-Credential)
+            .EXAMPLE
+            Get-ADSIPrincipalGroupMembership -Identity 'User1' -Credential (Get-Credential)
 
-    Use a different credential to perform the query
+            Use a different credential to perform the query
 
-.EXAMPLE
-    Get-ADSIPrincipalGroupMembership -Identity 'User1' -DomainName "CONTOSO.local"
+            .EXAMPLE
+            Get-ADSIPrincipalGroupMembership -Identity 'User1' -DomainName "CONTOSO.local"
 
-    Use a different domain name to perform the query
+            Use a different domain name to perform the query
 
-.EXAMPLE
-    Get-ADSIPrincipalGroupMembership -Identity 'Group1'
+            .EXAMPLE
+            Get-ADSIPrincipalGroupMembership -Identity 'Group1'
 
-    Get all AD groups of group Group1
+            Get all AD groups of group Group1
 
-.EXAMPLE
-    Get-ADSIPrincipalGroupMembership -Identity 'Group1' -Credential (Get-Credential)
+            .EXAMPLE
+            Get-ADSIPrincipalGroupMembership -Identity 'Group1' -Credential (Get-Credential)
 
-    Use a different credential to perform the query
+            Use a different credential to perform the query
 
-.EXAMPLE
-    Get-ADSIPrincipalGroupMembership -Identity 'Group1' -DomainName "CONTOSO.local"
+            .EXAMPLE
+            Get-ADSIPrincipalGroupMembership -Identity 'Group1' -DomainName "CONTOSO.local"
 
-    Use a different domain name to perform the query
+            Use a different domain name to perform the query
 
-.EXAMPLE
-    Get-ADSIPrincipalGroupMembership -UserInfos (Get-ADSIUser -Identity "User1")
+            .EXAMPLE
+            Get-ADSIPrincipalGroupMembership -UserInfos (Get-ADSIUser -Identity "User1")
 
-    Get all ad groups of User1 using type System.DirectoryServices.AccountManagement.AuthenticablePrincipal
+            Get all ad groups of User1 using type System.DirectoryServices.AccountManagement.AuthenticablePrincipal
     
-.EXAMPLE
-    Get-ADSIPrincipalGroupMembership -UserInfos (Get-ADSIUser -Identity "User1" -DomainName "CONTOSO.local")
+            .EXAMPLE
+            Get-ADSIPrincipalGroupMembership -UserInfos (Get-ADSIUser -Identity "User1" -DomainName "CONTOSO.local")
 
-    Get all ad groups of User1 using type System.DirectoryServices.AccountManagement.AuthenticablePrincipal on a different domain
+            Get all ad groups of User1 using type System.DirectoryServices.AccountManagement.AuthenticablePrincipal on a different domain
 
-.EXAMPLE
-    Get-ADSIPrincipalGroupMembership -GroupInfos (Get-ADSIGroup -Identity "Group1")
+            .EXAMPLE
+            Get-ADSIPrincipalGroupMembership -GroupInfos (Get-ADSIGroup -Identity "Group1")
 
-    Get all ad groups of Group1 using type System.DirectoryServices.AccountManagement.Principal
+            Get all ad groups of Group1 using type System.DirectoryServices.AccountManagement.Principal
     
-.EXAMPLE
-    Get-ADSIPrincipalGroupMembership -GroupInfos (Get-ADSIGroup -Identity "Group1" -DominName "CONTOSO.local")
+            .EXAMPLE
+            Get-ADSIPrincipalGroupMembership -GroupInfos (Get-ADSIGroup -Identity "Group1" -DominName "CONTOSO.local")
 
-    Get all ad groups of Group1 using type System.DirectoryServices.AccountManagement.Principal on a different domain
+            Get all ad groups of Group1 using type System.DirectoryServices.AccountManagement.Principal on a different domain
 
-.NOTES
-    https://github.com/lazywinadmin/ADSIPS
-#>
+            .NOTES
+            https://github.com/lazywinadmin/ADSIPS
+            CHANGE LOG
+            - 0.1 | 2019/06/22 | Matt Oestreich (oze4)
+                - Initial Change Log creation
+                - Fixed issue where primary group was not being pulled in for users
+                - Issue #70: https://github.com/lazywinadmin/AdsiPS/issues/70
+    #>
     [CmdletBinding()]
     param
     (
@@ -115,11 +120,14 @@ Function Get-ADSIPrincipalGroupMembership
 
     begin
     {
+        # Stores our output
+        $ObjectGroups = @()
 
         switch($PSBoundParameters.Keys)
         {
             'UserInfos'  { 
-                $UnderlyingProperties = $UserInfos.GetUnderlyingObject() 
+                $UnderlyingProperties = $UserInfos.GetUnderlyingObject()
+                $ObjectGroups += Get-ADSIUserPrimaryGroup -Identity $UserInfos -ReturnNameAndDescriptionOnly
             }
 
             'GroupInfos' {
@@ -128,60 +136,53 @@ Function Get-ADSIPrincipalGroupMembership
             
             'Identity'   {
 
-                # If the user supplies a GroupPrincipal or UserPrincipal under the 'Identity' parameter
-                if (($Identity.GetType().Name -eq "GroupPrincipal") -or ($Identity.GetType().Name -eq "UserPrincipal")) {
-                                                
-                    $UnderlyingProperties = $Identity.GetUnderlyingObject()                
+                $ObjectSplatting = @{}
+                if ($PSBoundParameters["DomainName"]) {                        
+                    # Turn Domain Name into DN
+                    $ObjectSplatting.DomainDistinguishedName = ($DomainName.Split(".").ForEach({ "DC=$($_)," }) -join '').TrimEnd(',')                        
+                }
 
-                } else {
-                    
-                    $ObjectSplatting  = @{}
-
-                    if ($PSBoundParameters["DomainName"]) {                        
-                        # Turn Domain Name into DN
-                        $ObjectSplatting.DomainDistinguishedName = ($DomainName.Split(".").ForEach({ "DC=$($_)," }) -join '').TrimEnd(',')                        
-                    }
-
-                    if ($PSBoundParameters["Credential"]) {
-                        $ObjectSplatting.Credential  = $Credential
-                    }
+                if ($PSBoundParameters["Credential"]) {
+                    $ObjectSplatting.Credential  = $Credential
+                }
                                     
-                    $FoundObject = $null
-                    # Get the ADSIObject for what we were provided
-                    foreach($IdType in [System.DirectoryServices.AccountManagement.IdentityType].GetEnumNames()) {                        
-                        $splat = @{ 
-                            $IdType = $Identity
-                        }                        
-                        
-                        try { 
-                            $FoundObject = Get-ADSIObject @splat @ObjectSplatting
-                        } catch {
-                            # do nothing, only here to suppress errors
-                        } 
-                        
-                        if ($FoundObject -ne $null) { 
-                            $FoundObjectObjectClass = $FoundObject.objectclass.Split(" ")
-                            break; 
-                        }
+                $FoundObject = $null
+                # Get the ADSIObject for what we were provided
+                foreach($IdType in [System.DirectoryServices.AccountManagement.IdentityType].GetEnumNames()) {                        
+                    $splat = @{ 
+                        $IdType = $Identity
                     }
-
-                    if ($FoundObjectObjectClass -contains "person" -or $FoundObjectObjectClass -contains "user") {
-                        $UserInfos = Get-ADSIUser -Identity $FoundObject.samaccountName
-                        $UnderlyingProperties = $UserInfos.GetUnderlyingObject()
-                    }
-
-                    if ($FoundObjectObjectClass -contains "group") {
-                        $GroupInfos = Get-ADSIGroup -Identity $FoundObject.samaccountName
-                        $UnderlyingProperties = $GroupInfos.GetUnderlyingObject()
+                        
+                    try { 
+                        if ($ObjectSplatting) { $FoundObject = Get-ADSIObject @splat @ObjectSplatting } 
+                        else { $FoundObject = Get-ADSIObject @splat }
+                    } catch {
+                        # do nothing, only here to suppress errors
+                    } 
+                        
+                    if ($FoundObject -ne $null) { 
+                        $FoundObjectObjectClass = $FoundObject.objectclass.Split(" ")
+                        break; 
                     }
                 }
+
+                if (($FoundObjectObjectClass -contains "person") -or ($FoundObjectObjectClass -contains "user")) {
+                    $UserInfos = Get-ADSIUser -Identity $FoundObject.samaccountName
+                    $UnderlyingProperties = $UserInfos.GetUnderlyingObject()
+                    $ObjectGroups += Get-ADSIUserPrimaryGroup -Identity $UserInfos -ReturnNameAndDescriptionOnly
+                }
+
+                if ($FoundObjectObjectClass -contains "group") {
+                    $GroupInfos = Get-ADSIGroup -Identity $FoundObject.samaccountName
+                    $UnderlyingProperties = $GroupInfos.GetUnderlyingObject()
+                }
+                
             }
         }
     }
     process
     {
-
-        $ObjectGroups   = @()        
+    
         $Objectmemberof = $UnderlyingProperties.memberOf
 
         if ($Objectmemberof)

--- a/src/public/Get-ADSIPrincipalGroupMembership.ps1
+++ b/src/public/Get-ADSIPrincipalGroupMembership.ps1
@@ -94,8 +94,7 @@ Function Get-ADSIPrincipalGroupMembership
             CHANGE LOG
             - 0.1 | 2019/06/22 | Matt Oestreich (oze4)
                 - Initial Change Log creation
-                - Fixed issue where primary group was not being pulled in for users
-                - Issue #70: https://github.com/lazywinadmin/AdsiPS/issues/70
+                - Fixed issue 70 where primary group was not being pulled in for users
     #>
     [CmdletBinding()]
     param

--- a/src/public/Get-ADSIUser.ps1
+++ b/src/public/Get-ADSIUser.ps1
@@ -71,14 +71,6 @@ function Get-ADSIUser
 
 .NOTES
     https://github.com/lazywinadmin/ADSIPS
-    CHANGE HISTORY
-    -0.1 | 2019/06/22 | Matt Oestreich (oze4)
-        - Added Change History section to comments
-        - Resolving issue #72: https://github.com/lazywinadmin/AdsiPS/issues/72
-        - Resolution has been tested and verified (can still add '-Domain' or '-Credential' params if need be)
-        - No longer have to specify `-Identity` param explicitly, now able to supply only a value
-            - ex: (no longer have to do this) Get-ADSIUser -Identity 'Some.Name'
-            - ex: (now you can simply do)     Get-ADSIUser 'Some.Name'
 
 .LINK
     https://msdn.microsoft.com/en-us/library/System.DirectoryServices.AccountManagement.UserPrincipal(v=vs.110).aspx
@@ -88,7 +80,7 @@ function Get-ADSIUser
     [OutputType('System.DirectoryServices.AccountManagement.UserPrincipal')]
     param
     (
-        [Parameter(Mandatory = $true, Position = 0, ParameterSetName = "Identity")]
+        [Parameter(Mandatory = $true, ParameterSetName = "Identity")]
         [string]$Identity,
 
         [Alias("RunAs")]

--- a/src/public/Get-ADSIUser.ps1
+++ b/src/public/Get-ADSIUser.ps1
@@ -71,9 +71,7 @@ function Get-ADSIUser
 
 .NOTES
     https://github.com/lazywinadmin/ADSIPS
-    ----------------
     CHANGE HISTORY
-    ----------------
     -0.1 | 2019/06/22 | Matt Oestreich (oze4)
         - Added Change History section to comments
         - Resolving issue #72: https://github.com/lazywinadmin/AdsiPS/issues/72

--- a/src/public/Get-ADSIUser.ps1
+++ b/src/public/Get-ADSIUser.ps1
@@ -71,6 +71,12 @@ function Get-ADSIUser
 
 .NOTES
     https://github.com/lazywinadmin/ADSIPS
+    ----------------
+    CHANGE HISTORY
+    ----------------
+    -0.1 | 2019/06/22 | Matt Oestreich (oze4)
+        - Added Change History section to comments
+        - Resolving issue 72
 
 .LINK
     https://msdn.microsoft.com/en-us/library/System.DirectoryServices.AccountManagement.UserPrincipal(v=vs.110).aspx
@@ -80,7 +86,7 @@ function Get-ADSIUser
     [OutputType('System.DirectoryServices.AccountManagement.UserPrincipal')]
     param
     (
-        [Parameter(Mandatory = $true, ParameterSetName = "Identity")]
+        [Parameter(Mandatory = $true, Position = 0, ParameterSetName = "Identity")]
         [string]$Identity,
 
         [Alias("RunAs")]

--- a/src/public/Get-ADSIUserPrimaryGroup.ps1
+++ b/src/public/Get-ADSIUserPrimaryGroup.ps1
@@ -24,6 +24,7 @@ function Get-ADSIUserPrimaryGroup
             Get primary AD group of user User1
 
             .NOTES
+            https://github.com/lazywinadmin/ADSIPS
             CHANGE LOG
             -1.0 | 2019/06/22 | Matt Oestreich (oze4)
                 - Initial creation

--- a/src/public/Get-ADSIUserPrimaryGroup.ps1
+++ b/src/public/Get-ADSIUserPrimaryGroup.ps1
@@ -1,0 +1,57 @@
+function Get-ADSIUserPrimaryGroup
+{
+    <#
+            .SYNOPSIS
+            Function to retrieve User's primary group
+
+            .DESCRIPTION
+            Get primary AD group of a user
+
+            .PARAMETER Identity
+            Specifies the Identity of the User
+            Uses the return of "Get-ADSIUser"
+
+            .PARAMETER ReturnNameAndDescriptionOnly
+            Returns a PSCustomObject of just the name and description
+            ex: $return = [pscustomobject]@{
+            'name'        = [string]$primaryGroup.Properties.name
+            'description' = [string]$primaryGroup.Properties.description
+            }
+
+            .EXAMPLE
+            Get-ADSIUserPrimaryGroup -Identity (Get-ADSIUser 'User1')
+
+            Get primary AD group of user User1
+
+            .NOTES
+            CHANGE LOG
+            -1.0 | 2019/06/22 | Matt Oestreich (oze4)
+                - Initial creation
+    #>
+    
+    param(
+        [Parameter(Mandatory=$true)]
+        [System.DirectoryServices.AccountManagement.AuthenticablePrincipal]$Identity,
+        
+        [Parameter(Mandatory=$false)]
+        [switch]$ReturnNameAndDescriptionOnly
+    )
+
+    try { 
+        $UnderlyingProperties = $Identity.GetUnderlyingObject()
+        $userSid  = (New-Object System.Security.Principal.SecurityIdentifier ($($UnderlyingProperties.properties.objectSID), 0)).AccountDomainSid.Value
+        $groupSid = ('{0}-{1}' -f $userSid, $UnderlyingProperties.properties.primarygroupid.ToString())
+        $primaryGroup = [adsi]("LDAP://<SID=$groupSid>")
+        if ($PSBoundParameters["ReturnNameAndDescriptionOnly"]) {
+            [pscustomobject]@{
+                'name'        = [string]$primaryGroup.Properties.name
+                'description' = [string]$primaryGroup.Properties.description
+            }
+        } else {
+            $primaryGroup
+        }
+    } catch {
+        $PSCmdlet.ThrowTerminatingError($_)
+    }
+
+}


### PR DESCRIPTION
## The following changes were made

- ### Bug Fix
  - Fixed issue #70 
  - This was due to Primary User Group not being added to overall Group Membership
- ### Formatting in README.md
  - Numbering was not correct in regards to the last changes made
  - Cleaned it up
- ### Added `Get-ADSIUserPrimaryGroup.ps1`
  - This was added as part of the resolution for issue #70 
  - By putting this function in it's own `ps1` file, it keeps things clean and organized
  - Provides an additional 'feature' (is not limited to helping fix issue #70 - you can now get a users primary group very easily)

@lazywinadmin - apologies for all of the pull requests lately!  I wanted to make sure to get these fixed, though. 