### PR TITLE
Fix ParameterSetName

### DIFF
--- a/src/public/Get-ADSIComputer.ps1
+++ b/src/public/Get-ADSIComputer.ps1
@@ -55,7 +55,7 @@ function Get-ADSIComputer
 .LINK
     https://msdn.microsoft.com/en-us/library/system.directoryservices.accountmanagement.computerprincipal(v=vs.110).aspx
 #>
-    [CmdletBinding(DefaultParameterSetName = "All")]
+    [CmdletBinding()]
     param ([Parameter(Mandatory = $true, ParameterSetName = "Identity")]
         [string]$Identity,
 

--- a/src/public/Get-ADSIUser.ps1
+++ b/src/public/Get-ADSIUser.ps1
@@ -75,7 +75,7 @@ function Get-ADSIUser
     https://msdn.microsoft.com/en-us/library/System.DirectoryServices.AccountManagement.UserPrincipal(v=vs.110).aspx
 #>
 
-    [CmdletBinding(DefaultParameterSetName = "All")]
+    [CmdletBinding()]
     [OutputType('System.DirectoryServices.AccountManagement.UserPrincipal')]
     param
     (
@@ -92,8 +92,6 @@ function Get-ADSIUser
         [Parameter(Mandatory = $true, ParameterSetName = "LDAPFilter")]
         [string]$LDAPFilter,
 
-        [Parameter(ParameterSetName = "LDAPFilter")]
-        [Parameter(ParameterSetName = "All")]
         [Switch]$NoResultLimit
 
     )


### PR DESCRIPTION
DefaultParameterSetName = "All" not needed if no ParameterSetName = "All" exist
And ParameterSetName = "All" not needed in Get-ADSIUser