### PR TITLE
Fix missing FunctionName in Verbose Messages

### DIFF
--- a/src/public/Compare-ADSITeamGroups.ps1
+++ b/src/public/Compare-ADSITeamGroups.ps1
@@ -84,6 +84,7 @@ Function Compare-ADSITeamGroups
 
     begin
     {
+        $FunctionName = (Get-Variable -Name MyInvocation -Scope 0 -ValueOnly).Mycommand
         # Create Context splatting
         $ContextSplatting = @{ }
         if ($PSBoundParameters['Credential'])

--- a/src/public/Disable-ADSIComputer.ps1
+++ b/src/public/Disable-ADSIComputer.ps1
@@ -65,6 +65,7 @@ function Disable-ADSIComputer
 
     begin
     {
+        $FunctionName = (Get-Variable -Name MyInvocation -Scope 0 -ValueOnly).Mycommand
         Add-Type -AssemblyName System.DirectoryServices.AccountManagement
 
         # Create Context splatting

--- a/src/public/Disable-ADSIUser.ps1
+++ b/src/public/Disable-ADSIUser.ps1
@@ -68,6 +68,7 @@ function Disable-ADSIUser
 
     begin
     {
+        $FunctionName = (Get-Variable -Name MyInvocation -Scope 0 -ValueOnly).Mycommand
         Add-Type -AssemblyName System.DirectoryServices.AccountManagement
 
         # Create Context splatting

--- a/src/public/Enable-ADSIComputer.ps1
+++ b/src/public/Enable-ADSIComputer.ps1
@@ -65,6 +65,7 @@ function Enable-ADSIComputer
 
     begin
     {
+        $FunctionName = (Get-Variable -Name MyInvocation -Scope 0 -ValueOnly).Mycommand
         Add-Type -AssemblyName System.DirectoryServices.AccountManagement
 
         # Create Context splatting

--- a/src/public/Enable-ADSIUser.ps1
+++ b/src/public/Enable-ADSIUser.ps1
@@ -69,6 +69,7 @@ function Enable-ADSIUser
 
     begin
     {
+        $FunctionName = (Get-Variable -Name MyInvocation -Scope 0 -ValueOnly).Mycommand
         Add-Type -AssemblyName System.DirectoryServices.AccountManagement
 
         # Create Context splatting

--- a/src/public/Get-ADSIComputer.ps1
+++ b/src/public/Get-ADSIComputer.ps1
@@ -68,6 +68,7 @@ function Get-ADSIComputer
     )
     begin
     {
+        $FunctionName = (Get-Variable -Name MyInvocation -Scope 0 -ValueOnly).Mycommand
         Add-Type -AssemblyName System.DirectoryServices.AccountManagement
 
         # Create Context splatting

--- a/src/public/Get-ADSIDomain.ps1
+++ b/src/public/Get-ADSIDomain.ps1
@@ -54,6 +54,7 @@
     )
     process
     {
+        $FunctionName = (Get-Variable -Name MyInvocation -Scope 0 -ValueOnly).Mycommand
         try
         {
             if ($PSBoundParameters['Credential'] -or $PSBoundParameters['DomainName'])

--- a/src/public/Get-ADSIDomainController.ps1
+++ b/src/public/Get-ADSIDomainController.ps1
@@ -40,14 +40,14 @@
 
     begin
     {
-
+        $FunctionName = (Get-Variable -Name MyInvocation -Scope 0 -ValueOnly).Mycommand
 
         if ($PSBoundParameters['Credential'])
         {
             Write-Verbose "[$FunctionName] Found Credential Parameter"
             $Context = New-ADSIDirectoryContext -Credential $Credential -contextType Domain
             if ($PSBoundParameters['DomainName'])
-            {   
+            {
                 Write-Verbose "[$FunctionName] Found DomainName Parameter"
                 $Context = New-ADSIDirectoryContext -Credential $Credential -contextType Domain -DomainName $DomainName
             }


### PR DESCRIPTION
As Mentioned in the comments of PR #110 the definition of $FunctionName was missing but the Variable FunctionName is used in all of the changed files. This PR just adds the missing line to the changed functions, to fix this issue.
