### PR TITLE
Added Pipeline Support to multiple Functions

### DIFF
--- a/src/public/Copy-ADSIGroupMembership.ps1
+++ b/src/public/Copy-ADSIGroupMembership.ps1
@@ -52,7 +52,8 @@ function Copy-ADSIGroupMembership{
     param(
         [Parameter(Mandatory = $true,
             Position = 0,
-            ParameterSetName = "Identity")]
+            ParameterSetName = "Identity",
+            ValueFromPipeline = $true)]
         [System.string]$SourceIdentity,
 
         [Parameter(Mandatory = $true,
@@ -82,9 +83,16 @@ function Copy-ADSIGroupMembership{
             Write-Verbose "[$FunctionName] Found DomainName Parameter"
             $ContextSplatting.DomainName = $DomainName
         }
+    }
+
+    process{
 
         #Get SourceIdentity Type
-        $SourceObject = Get-ADSIObject -Identity $SourceIdentity @ContextSplatting
+        if($SourceIdentity.GetType().FullName -eq 'System.String'){
+            $SourceObject = Get-ADSIObject -Identity $SourceIdentity @ContextSplatting
+        } else {
+            $SourceObject = Get-ADSIObject -Identity $SourceIdentity.DistinguishedName @ContextSplatting
+        }
         $DestinationObject = Get-ADSIObject -Identity $DestinationIdentity @ContextSplatting
 
         switch -Wildcard ($SourceObject.objectclass){
@@ -98,9 +106,7 @@ function Copy-ADSIGroupMembership{
             "*computer" {$DestinationType = "Computer"}
             "*user" {$DestinationType = "User"}
         }
-    }
 
-    process{
         #GetSourceGroups
         If($SourceType -eq "User"){
             $SourceGroups = (Get-ADSIUser -Identity $SourceIdentity @ContextSplatting).GetGroups()

--- a/src/public/Move-ADSIComputer.ps1
+++ b/src/public/Move-ADSIComputer.ps1
@@ -41,8 +41,8 @@ function Move-ADSIComputer
     https://msdn.microsoft.com/en-us/library/system.directoryservices.accountmanagement.computerprincipal(v=vs.110).aspx
 #>
     [CmdletBinding()]
-    param ([Parameter(Mandatory = $true)]
-        [string]$Identity,
+    param ([Parameter(Mandatory = $true, ValueFromPipeline = $true)]
+        $Identity,
 
         [Alias("RunAs")]
         [System.Management.Automation.PSCredential]
@@ -76,7 +76,11 @@ function Move-ADSIComputer
     {
         try
         {
-            $Computer = [System.DirectoryServices.AccountManagement.ComputerPrincipal]::FindByIdentity($Context, $Identity)
+            if($Identity.GetType().FullName -eq 'System.String'){
+                $Computer = [System.DirectoryServices.AccountManagement.ComputerPrincipal]::FindByIdentity($Context, $Identity)
+            } else {
+                $Computer = $Identity
+            }
 
             # Retrieve DirectoryEntry
             #$Computer.GetUnderlyingObject()

--- a/src/public/Move-ADSIGroup.ps1
+++ b/src/public/Move-ADSIGroup.ps1
@@ -46,8 +46,8 @@ function Move-ADSIGroup
     [OutputType('System.DirectoryServices.AccountManagement.GroupPrincipal')]
     param
     (
-        [Parameter(Mandatory = $true)]
-        [string]$Identity,
+        [Parameter(Mandatory = $true, ValueFromPipeline = $true)]
+        $Identity,
 
         [Alias("RunAs")]
         [System.Management.Automation.PSCredential]
@@ -82,7 +82,11 @@ function Move-ADSIGroup
     {
         try
         {
-            $Group = [System.DirectoryServices.AccountManagement.GroupPrincipal]::FindByIdentity($Context, $Identity)
+            if($Identity.GetType().FullName -eq 'System.String'){
+                $Group = [System.DirectoryServices.AccountManagement.GroupPrincipal]::FindByIdentity($Context, $Identity)
+            } else {
+                $Group = $Identity
+            }
 
             # Create DirectoryEntry object
             $NewDirectoryEntry = New-Object -TypeName System.DirectoryServices.DirectoryEntry -ArgumentList "LDAP://$Destination"

--- a/src/public/Move-ADSIUser.ps1
+++ b/src/public/Move-ADSIUser.ps1
@@ -49,8 +49,8 @@ function Move-ADSIUser
     [OutputType('System.DirectoryServices.AccountManagement.UserPrincipal')]
     param
     (
-        [Parameter(Mandatory = $true)]
-        [string]$Identity,
+        [Parameter(Mandatory = $true, ValueFromPipeline = $true)]
+        $Identity,
 
         [Alias("RunAs")]
         [System.Management.Automation.PSCredential]
@@ -84,7 +84,11 @@ function Move-ADSIUser
     {
         if ($Identity)
         {
-            $user = [System.DirectoryServices.AccountManagement.UserPrincipal]::FindByIdentity($Context, $Identity)
+            if($Identity.GetType().FullName -eq 'System.String'){
+                $user = [System.DirectoryServices.AccountManagement.UserPrincipal]::FindByIdentity($Context, $Identity)
+            } else {
+                $user = $Identity
+            }
 
             # Retrieve DirectoryEntry
             #$User.GetUnderlyingObject()

--- a/src/public/Reset-ADSIUserPasswordAge.ps1
+++ b/src/public/Reset-ADSIUserPasswordAge.ps1
@@ -26,8 +26,8 @@ function Reset-ADSIUserPasswordAge
     [CmdletBinding(SupportsShouldProcess = $true)]
     param
     (
-        [Parameter(Mandatory = $true)]
-        [string]$Identity,
+        [Parameter(Mandatory = $true, ValueFromPipeline = $true)]
+        $Identity,
 
         [Alias("RunAs")]
         [System.Management.Automation.PSCredential]

--- a/src/public/Set-ADSIComputer.ps1
+++ b/src/public/Set-ADSIComputer.ps1
@@ -45,8 +45,8 @@ function Set-ADSIComputer
 #>
     [CmdletBinding(SupportsShouldProcess = $true, ConfirmImpact = 'High', DefaultParameterSetName = 'Default')]
     param (
-        [Parameter(Mandatory = $true)]
-        [String]$Identity,
+        [Parameter(Mandatory = $true, ValueFromPipeline = $true)]
+        $Identity,
 
         [Parameter(Mandatory = $false)]
         [string]$Description,

--- a/src/public/Set-ADSIGroup.ps1
+++ b/src/public/Set-ADSIGroup.ps1
@@ -37,8 +37,8 @@ function Set-ADSIGroup
 #>
     [CmdletBinding(SupportsShouldProcess = $true, ConfirmImpact = 'High', DefaultParameterSetName = 'Default')]
     param (
-        [Parameter(Mandatory = $true)]
-        [String]$Identity,
+        [Parameter(Mandatory = $true, ValueFromPipeline = $true)]
+        $Identity,
 
         [Parameter(Mandatory = $false)]
         [string]$Description,

--- a/src/public/Set-ADSIUser.ps1
+++ b/src/public/Set-ADSIUser.ps1
@@ -81,8 +81,8 @@ function Set-ADSIUser
 #>
     [CmdletBinding(SupportsShouldProcess = $true, ConfirmImpact = 'High', DefaultParameterSetName = 'Default')]
     param (
-        [Parameter(Mandatory = $true)]
-        [String]$Identity,
+        [Parameter(Mandatory = $true, ValueFromPipeline = $true)]
+        $Identity,
 
         [Parameter(Mandatory = $false)]
         [string]$Country,

--- a/src/public/Set-ADSIUserPassword.ps1
+++ b/src/public/Set-ADSIUserPassword.ps1
@@ -38,7 +38,7 @@
 #>
     [CmdletBinding(SupportsShouldProcess = $true)]
     param (
-        [parameter(Mandatory = $true)]
+        [parameter(Mandatory = $true, ValueFromPipeline = $true)]
         $Identity,
 
         [parameter(Mandatory = $true)]

--- a/src/public/Test-ADSIUserIsLockedOut.ps1
+++ b/src/public/Test-ADSIUserIsLockedOut.ps1
@@ -27,8 +27,8 @@ function Test-ADSIUserIsLockedOut
     [OutputType('System.Boolean')]
     param
     (
-        [Parameter(Mandatory = $true)]
-        [string]$Identity,
+        [Parameter(Mandatory = $true,ValueFromPipeline = $true)]
+        $Identity,
 
         [Alias("RunAs")]
         [System.Management.Automation.PSCredential]

--- a/src/public/Unlock-ADSIComputer.ps1
+++ b/src/public/Unlock-ADSIComputer.ps1
@@ -27,8 +27,8 @@ function Unlock-ADSIComputer
     https://github.com/lazywinadmin/ADSIPS
 #>
     [CmdletBinding()]
-    param ([Parameter(Mandatory)]
-        [string]$Identity,
+    param ([Parameter(Mandatory, ValueFromPipeline = $true)]
+        $Identity,
 
         [Alias("RunAs")]
         [System.Management.Automation.PSCredential]

--- a/src/public/Unlock-ADSIUser.ps1
+++ b/src/public/Unlock-ADSIUser.ps1
@@ -27,8 +27,8 @@ function Unlock-ADSIUser
     https://github.com/lazywinadmin/ADSIPS
 #>
     [CmdletBinding()]
-    param ([Parameter(Mandatory)]
-        [string]$Identity,
+    param ([Parameter(Mandatory, ValueFromPipeline = $true)]
+        $Identity,
 
         [Alias("RunAs")]
         [System.Management.Automation.PSCredential]


### PR DESCRIPTION
As the most "Underlying" Function like Get-ADSI* already accepts a Object as Identity Parameter its very simple to implement Pipeline Support to many other functions.
In this PR i done this implementations for 12 function.
Now you can use multiple functions together like:
`
Get-ADSIUser -Identity 'TestUser' | Unlock-ADSIUser
`