### PR TITLE
implement LDAPFilter (fix #62)

### DIFF
--- a/src/public/Get-ADSIComputer.ps1
+++ b/src/public/Get-ADSIComputer.ps1
@@ -20,6 +20,13 @@ function Get-ADSIComputer
     System.DirectoryService.AccountManagement.IdentityType
     https://msdn.microsoft.com/en-us/library/bb356425(v=vs.110).aspx
 
+.PARAMETER LDAPFilter
+    A custom LDAP Filter string to search for computer objects.
+    May not be used together with -Identity.
+
+.PARAMETER LDAPPath
+    The directory path to search inside when using an LDAPFilter.
+
 .PARAMETER Credential
     Specifies alternative credential
     By default it will use the current user windows credentials.
@@ -56,8 +63,14 @@ function Get-ADSIComputer
     https://msdn.microsoft.com/en-us/library/system.directoryservices.accountmanagement.computerprincipal(v=vs.110).aspx
 #>
     [CmdletBinding(DefaultParameterSetName = "All")]
-    param ([Parameter(Mandatory = $true, Position = 0, ParameterSetName = "Identity")]
+    param (
+        [Parameter(Mandatory = $true, Position = 0, ParameterSetName = "Identity")]
         [string]$Identity,
+        
+        [Parameter(ParameterSetName = "LDAPFilter")]
+        [string]$LDAPFilter,
+        [Parameter(ParameterSetName = "LDAPFilter")]
+        [string]$LDAPPath,
 
         [Alias("RunAs")]
         [System.Management.Automation.PSCredential]
@@ -68,41 +81,73 @@ function Get-ADSIComputer
     )
     begin
     {
-        $FunctionName = (Get-Variable -Name MyInvocation -Scope 0 -ValueOnly).Mycommand
-        Add-Type -AssemblyName System.DirectoryServices.AccountManagement
+        switch ($PsCmdlet.ParameterSetName) {
+            'Identity' {
+                $FunctionName = (Get-Variable -Name MyInvocation -Scope 0 -ValueOnly).Mycommand
+                Add-Type -AssemblyName System.DirectoryServices.AccountManagement
 
-        # Create Context splatting
-        $ContextSplatting = @{ ContextType = "Domain" }
+                # Create Context splatting
+                $ContextSplatting = @{ ContextType = "Domain" }
 
-        if ($PSBoundParameters['Credential'])
-        {
-            Write-Verbose "[$FunctionName] Found Credential Parameter"
-            $ContextSplatting.Credential = $Credential
+                if ($PSBoundParameters['Credential'])
+                {
+                    Write-Verbose "[$FunctionName] Found Credential Parameter"
+                    $ContextSplatting.Credential = $Credential
+                }
+                if ($PSBoundParameters['DomainName'])
+                {
+                    Write-Verbose "[$FunctionName] Found DomainName Parameter"
+                    $ContextSplatting.DomainName = $DomainName
+                }
+
+                $Context = New-ADSIPrincipalContext @ContextSplatting
+            }
+            
+            'LDAPFilter' {
+                $FunctionName = (Get-Variable -Name MyInvocation -Scope 0 -ValueOnly).Mycommand
+                
+                # Create Context splatting
+                $ContextSplatting = @{}
+
+                if ($PSBoundParameters['Credential'])
+                {
+                    Write-Verbose "[$FunctionName] Found Credential Parameter"
+                    $ContextSplatting.Credential = $Credential
+                }
+                if ($PSBoundParameters['LDAPPath'])
+                {
+                    Write-Verbose "[$FunctionName] Found LADPPath Parameter"
+                    $ContextSplatting.Path = $LDAPPath
+                }
+
+                $SearchRoot = New-ADSIDirectoryEntry @ContextSplatting
+            }
         }
-        if ($PSBoundParameters['DomainName'])
-        {
-            Write-Verbose "[$FunctionName] Found DomainName Parameter"
-            $ContextSplatting.DomainName = $DomainName
-        }
-
-        $Context = New-ADSIPrincipalContext @ContextSplatting
-
     }
     process
     {
         try
         {
-            if ($Identity)
-            {
-                [System.DirectoryServices.AccountManagement.ComputerPrincipal]::FindByIdentity($Context, $Identity)
-            }
-            else
-            {
-                $ComputerPrincipal = New-object -TypeName System.DirectoryServices.AccountManagement.ComputerPrincipal -ArgumentList $Context
-                $Searcher = new-object -TypeName System.DirectoryServices.AccountManagement.PrincipalSearcher
-                $Searcher.QueryFilter = $ComputerPrincipal
+            switch ($PsCmdlet.ParameterSetName) {
+                'Identity' {
+                    [System.DirectoryServices.AccountManagement.ComputerPrincipal]::FindByIdentity($Context, $Identity)
+                }
+                'LDAPFilter' {
+                    if ($LDAPFilter) {
+                        $LDAPFilter = "(&(objectClass=computer)$LDAPFilter)"
+                        $Searcher = New-Object -TypeName System.DirectoryServices.DirectorySearcher -ArgumentList $SearchRoot, $LDAPFilter
+                    } else {
+                        $Searcher = New-Object -TypeName System.DirectoryServices.DirectorySearcher -ArgumentList $SearchRoot, 'objectClass=computer'
+                    }
+                    $Searcher.FindAll() | Select-Object -ExpandProperty Properties
+                }
+                default {
+                    $ComputerPrincipal = New-object -TypeName System.DirectoryServices.AccountManagement.ComputerPrincipal -ArgumentList $Context
+                    $Searcher = new-object -TypeName System.DirectoryServices.AccountManagement.PrincipalSearcher
+                    $Searcher.QueryFilter = $ComputerPrincipal
 
-                $Searcher.FindAll()
+                    $Searcher.FindAll()
+                }
             }
         }
         catch

--- a/src/public/Get-ADSIComputer.ps1
+++ b/src/public/Get-ADSIComputer.ps1
@@ -82,27 +82,8 @@ function Get-ADSIComputer
     begin
     {
         $FunctionName = (Get-Variable -Name MyInvocation -Scope 0 -ValueOnly).Mycommand
-        Add-Type -AssemblyName System.DirectoryServices.AccountManagement
 
         switch ($PsCmdlet.ParameterSetName) {
-            'Identity' {
-                # Create Context splatting
-                $ContextSplatting = @{ ContextType = "Domain" }
-
-                if ($PSBoundParameters['Credential'])
-                {
-                    Write-Verbose "[$FunctionName] Found Credential Parameter"
-                    $ContextSplatting.Credential = $Credential
-                }
-                if ($PSBoundParameters['DomainName'])
-                {
-                    Write-Verbose "[$FunctionName] Found DomainName Parameter"
-                    $ContextSplatting.DomainName = $DomainName
-                }
-
-                $Context = New-ADSIPrincipalContext @ContextSplatting
-            }
-            
             'LDAPFilter' {
                 # Create Context splatting
                 $ContextSplatting = @{}
@@ -119,6 +100,25 @@ function Get-ADSIComputer
                 }
 
                 $SearchRoot = New-ADSIDirectoryEntry @ContextSplatting
+            }
+            default {
+                Add-Type -AssemblyName System.DirectoryServices.AccountManagement
+
+                # Create Context splatting
+                $ContextSplatting = @{ ContextType = "Domain" }
+
+                if ($PSBoundParameters['Credential'])
+                {
+                    Write-Verbose "[$FunctionName] Found Credential Parameter"
+                    $ContextSplatting.Credential = $Credential
+                }
+                if ($PSBoundParameters['DomainName'])
+                {
+                    Write-Verbose "[$FunctionName] Found DomainName Parameter"
+                    $ContextSplatting.DomainName = $DomainName
+                }
+
+                $Context = New-ADSIPrincipalContext @ContextSplatting
             }
         }
     }

--- a/src/public/Get-ADSIComputer.ps1
+++ b/src/public/Get-ADSIComputer.ps1
@@ -81,11 +81,11 @@ function Get-ADSIComputer
     )
     begin
     {
+        $FunctionName = (Get-Variable -Name MyInvocation -Scope 0 -ValueOnly).Mycommand
+        Add-Type -AssemblyName System.DirectoryServices.AccountManagement
+
         switch ($PsCmdlet.ParameterSetName) {
             'Identity' {
-                $FunctionName = (Get-Variable -Name MyInvocation -Scope 0 -ValueOnly).Mycommand
-                Add-Type -AssemblyName System.DirectoryServices.AccountManagement
-
                 # Create Context splatting
                 $ContextSplatting = @{ ContextType = "Domain" }
 
@@ -104,8 +104,6 @@ function Get-ADSIComputer
             }
             
             'LDAPFilter' {
-                $FunctionName = (Get-Variable -Name MyInvocation -Scope 0 -ValueOnly).Mycommand
-                
                 # Create Context splatting
                 $ContextSplatting = @{}
 


### PR DESCRIPTION
New -LDAPFilter and -LDAPPath parameters to implement #62

Minor refactoring, switching from if-statements to a switch-statement to more cleanly handle the newly introduced parameter set.

Makes use of the existing New-ADSIDirectoryEntry function.